### PR TITLE
feat: integrate Docker setup and add initial integration tests for me…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,10 @@ services:
     ports:
       - "8001:8001"
     volumes:
-      - ./src:/app
+      - .:/app
+    environment:
+      - PYTHONPATH=/app/src
+    command: uvicorn src.main:app --host 0.0.0.0 --port 8001 --reload
     depends_on:
       rabbitmq:
         condition: service_healthy

--- a/src/config.py
+++ b/src/config.py
@@ -2,12 +2,14 @@ from pydantic import SecretStr, AmqpDsn, RedisDsn
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import Optional
 
+
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_file='.env', env_file_encoding='utf-8', extra='ignore')
+    model_config = SettingsConfigDict(
+        env_file='.env', env_file_encoding='utf-8', extra='ignore')
 
     # Application
     APP_NAME: str = "Notification Service"
-    SERVICE_NAME: str = "notification-service" 
+    SERVICE_NAME: str = "notification-service"
     API_VERSION: str = "0.0.1"
     DEBUG: bool = True
     HOST: str = "0.0.0.0"
@@ -44,9 +46,11 @@ class Settings(BaseSettings):
     MAIL_SERVER: Optional[str] = None
     MAIL_STARTTLS: bool = True
     MAIL_SSL_TLS: bool = False
+    MAIL_SUPPRESS_SEND: bool = False
 
     @property
     def RABBITMQ_URL(self) -> AmqpDsn:
         return f"amqp://{self.RABBITMQ_USER}:{self.RABBITMQ_PASSWORD.get_secret_value()}@{self.RABBITMQ_HOST}:{self.RABBITMQ_PORT}/"
+
 
 settings = Settings()

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,0 +1,106 @@
+import pytest
+import asyncio
+import json
+import aio_pika
+from uuid import uuid4
+from datetime import datetime, UTC
+import redis.asyncio as aioredis
+
+from config import settings
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+async def publish_message(body_dict, routing_key=settings.RABBITMQ_ROUTING_KEY):
+
+    connection = await aio_pika.connect_robust(settings.RABBITMQ_URL)
+    async with connection:
+        channel = await connection.channel()
+        exchange = await channel.get_exchange(settings.RABBITMQ_EXCHANGE_MAIN)
+
+        message_body = json.dumps(body_dict, default=str).encode('utf-8')
+        message = aio_pika.Message(
+            body=message_body,
+            content_type="application/json",
+            correlation_id=str(uuid4()),
+            delivery_mode=aio_pika.DeliveryMode.PERSISTENT
+        )
+        await exchange.publish(message, routing_key=routing_key)
+
+
+async def check_idempotency_key_exists(message_id):
+    redis_client = aioredis.from_url(settings.REDIS_URL)
+    key = f"idempotency:{message_id}"
+    try:
+        exists = await redis_client.exists(key)
+        return exists > 0
+    finally:
+        await redis_client.aclose()
+
+
+async def get_message_from_dlq():
+    connection = await aio_pika.connect_robust(settings.RABBITMQ_URL)
+    async with connection:
+        channel = await connection.channel()
+        queue = await channel.declare_queue(settings.RABBITMQ_QUEUE_DLQ, durable=True, passive=True)
+
+        try:
+            message = await queue.get(fail=False)
+            if message:
+                await message.ack()
+                return json.loads(message.body.decode())
+            return None
+        except Exception:
+            return None
+
+
+@pytest.fixture
+def valid_payload():
+    return {
+        "message_id": str(uuid4()),
+        "timestamp": datetime.now(UTC).isoformat(),
+        "trigger_type": "integration_test",
+        "event_type": "INVOICE_DUE_SOON",
+        "recipient": {
+            "user_id": "integration-user",
+            "email": "integration@test.com",
+            "name": "Int User"
+        },
+        "payload": {
+            "credit_card": "Visa",
+            "month": 12,
+            "year": 2025,
+            "due_date": "2025-12-25",
+            "amount": 100.00,
+            "invoice_deep_link": "app://invoice"
+        }
+    }
+
+
+async def test_it001_consume_valid_message_successfully(valid_payload):
+
+    msg_id = valid_payload['message_id']
+
+    await publish_message(valid_payload)
+
+    await asyncio.sleep(2)
+
+    is_processed = await check_idempotency_key_exists(msg_id)
+    assert is_processed is True, "A chave de idempotência deveria existir no Redis"
+
+
+async def test_it003_invalid_event_goes_to_dlq(valid_payload):
+
+    valid_payload['event_type'] = "EVENTO_QUE_NAO_EXISTE"
+    valid_payload['message_id'] = str(uuid4())  # Novo ID
+
+    while await get_message_from_dlq():
+        pass
+
+    await publish_message(valid_payload)
+
+    await asyncio.sleep(2)
+
+    dlq_message = await get_message_from_dlq()
+    assert dlq_message is not None, "Deveria haver uma mensagem na DLQ"
+    assert dlq_message['message_id'] == valid_payload['message_id']


### PR DESCRIPTION
Esta PR finaliza a estratégia de testes do notification-service, adicionando a camada de Testes de Integração e ajustando a configuração do Docker para permitir a execução desses testes.

### Principais Alterações:

Testes de Integração (tests/integration/):

Adicionado fluxo de testes que valida a comunicação real com RabbitMQ e Redis.

Implementado caso IT-001 (Caminho feliz: consumo da fila e gravação de idempotência no Redis).

Implementado caso IT-003 (Tratamento de erro: envio para Dead Letter Queue em caso de evento inválido).

Configuração do Docker (docker-compose.yml):

Correção de Volume: O volume do serviço app foi alterado de ./src:/app para .:/app.

Motivo: O pytest precisa acessar a pasta tests/ e o arquivo pytest.ini que estão na raiz do projeto. O mapeamento antigo escondia esses arquivos do container.

PYTHONPATH: Adicionada variável PYTHONPATH=/app/src para garantir que os imports funcionem corretamente com a nova estrutura de pastas dentro do container.

Configurações de Aplicação (config.py e .env):

Adicionada a flag MAIL_SUPPRESS_SEND. Quando ativada (True), a biblioteca de e-mail simula o envio com sucesso sem tentar conectar externamente. Isso é importante para que os testes de integração passem localmente sem depender de um servidor SMTP real.

### Como Rodar os Testes:

Testes Unitários (Rápido/Local):

pytest tests/unit/
Testes de Integração (Requer Docker): Devem ser executados dentro do container para resolver os hostnames da rede interna.

### 1. Subir o ambiente
docker compose up -d --build

### 2. Executar os testes
docker compose exec app pytest -m integration -v